### PR TITLE
Added complex scalar addition and complex scalar multiplication, with further testing, found that scalar addition with negative numbers doesn't work.

### DIFF
--- a/api/CCParams.cpp
+++ b/api/CCParams.cpp
@@ -87,6 +87,13 @@ void CCParams<CryptoContextCKKSRNS>::SetSecurityLevel(SecurityLevel level) {
 	params.SetSecurityLevel(sl_openfhe);
 }
 
+void CCParams<CryptoContextCKKSRNS>::SetCKKSDataType(CKKSDataType ckksdt) {
+	auto& params	= std::any_cast<lbcrypto::CCParams<lbcrypto::CryptoContextCKKSRNS>&>(cpu);
+	auto dt_openfhe = static_cast<lbcrypto::CKKSDataType>(ckksdt);
+	assert((int)dt_openfhe == (int)ckksdt);
+	params.SetCKKSDataType(dt_openfhe);
+}
+
 // ---- Getters ----
 
 SecretKeyDist CCParams<CryptoContextCKKSRNS>::GetSecretKeyDist() const {

--- a/api/CCParams.hpp
+++ b/api/CCParams.hpp
@@ -49,6 +49,7 @@ template <> class CCParams<CryptoContextCKKSRNS> {
 	void SetDevices(std::vector<int>&& devices);
 	void SetPlaintextAutoload(bool autoload);
 	void SetCiphertextAutoload(bool autoload);
+	void SetCKKSDataType(CKKSDataType ckksdt);
 
 	// ---- Getters ----
 	SecretKeyDist GetSecretKeyDist() const;

--- a/api/CryptoContext.hpp
+++ b/api/CryptoContext.hpp
@@ -9,6 +9,7 @@
 #include <shared_mutex>
 #include <unordered_map>
 #include <vector>
+#include <complex>
 
 #include "CCParams.hpp"
 #include "Ciphertext.hpp"
@@ -115,11 +116,15 @@ template <> class CryptoContextImpl<DCRTPoly> {
 	Ciphertext<DCRTPoly> EvalAdd(Plaintext& pt, const Ciphertext<DCRTPoly>& ct);
 	Ciphertext<DCRTPoly> EvalAdd(const Ciphertext<DCRTPoly>& ct, double scalar);
 	Ciphertext<DCRTPoly> EvalAdd(double scalar, const Ciphertext<DCRTPoly>& ct);
+	Ciphertext<DCRTPoly> EvalAdd(const Ciphertext<DCRTPoly>& ct, std::complex<double> scalar);
+	Ciphertext<DCRTPoly> EvalAdd(std::complex<double> scalar, const Ciphertext<DCRTPoly>& ct);
 	void EvalAddInPlace(Ciphertext<DCRTPoly>& ct1, const Ciphertext<DCRTPoly>& ct2);
 	void EvalAddInPlace(Ciphertext<DCRTPoly>& ct1, Plaintext& pt);
 	void EvalAddInPlace(Plaintext& pt, Ciphertext<DCRTPoly>& ct1);
 	void EvalAddInPlace(Ciphertext<DCRTPoly>& ct1, double scalar);
 	void EvalAddInPlace(double scalar, Ciphertext<DCRTPoly>& ct1);
+	void EvalAddInPlace(Ciphertext<DCRTPoly>& ct1, std::complex<double> scalar);
+	void EvalAddInPlace(std::complex<double> scalar, Ciphertext<DCRTPoly>& ct1);
 	Ciphertext<DCRTPoly> EvalAddMutable(Ciphertext<DCRTPoly>& ct1, Ciphertext<DCRTPoly>& ct2);
 	Ciphertext<DCRTPoly> EvalAddMutable(Ciphertext<DCRTPoly>& ct, Plaintext& pt);
 	Ciphertext<DCRTPoly> EvalAddMutable(Plaintext& pt, Ciphertext<DCRTPoly>& ct);
@@ -146,9 +151,13 @@ template <> class CryptoContextImpl<DCRTPoly> {
 	Ciphertext<DCRTPoly> EvalMult(Plaintext& pt, const Ciphertext<DCRTPoly>& ct1);
 	Ciphertext<DCRTPoly> EvalMult(const Ciphertext<DCRTPoly>& ct1, double scalar);
 	Ciphertext<DCRTPoly> EvalMult(double scalar, const Ciphertext<DCRTPoly>& ct1);
+	Ciphertext<DCRTPoly> EvalMult(const Ciphertext<DCRTPoly>& ct1, std::complex<double> scalar);
+	Ciphertext<DCRTPoly> EvalMult(std::complex<double> scalar, const Ciphertext<DCRTPoly>& ct1);
 	void EvalMultInPlace(Ciphertext<DCRTPoly>& ct1, Plaintext& pt);
 	void EvalMultInPlace(Ciphertext<DCRTPoly>& ct1, double scalar);
 	void EvalMultInPlace(double scalar, Ciphertext<DCRTPoly>& ct1);
+	void EvalMultInPlace(Ciphertext<DCRTPoly>& ct1, std::complex<double> scalar);
+	void EvalMultInPlace(std::complex<double> scalar, Ciphertext<DCRTPoly>& ct1);
 	Ciphertext<DCRTPoly> EvalMultMutable(Ciphertext<DCRTPoly>& ct1, Ciphertext<DCRTPoly>& ct2);
 	Ciphertext<DCRTPoly> EvalMultMutable(Ciphertext<DCRTPoly>& ct1, Plaintext& pt);
 	Ciphertext<DCRTPoly> EvalMultMutable(Plaintext& pt, Ciphertext<DCRTPoly>& ct1);

--- a/api/Definitions.hpp
+++ b/api/Definitions.hpp
@@ -86,6 +86,11 @@ enum SecurityLevel {
     HEStd_NotSet,
 };
 
+enum CKKSDataType {
+    REAL = 0,
+    COMPLEX,
+};
+
 } // namespace fideslib
 
 #endif

--- a/other/GPUTest.cpp
+++ b/other/GPUTest.cpp
@@ -1,5 +1,6 @@
 #include <cuda_runtime.h>
 #include <iostream>
+#include <tuple>
 
 int main() {
     int deviceCount, device;

--- a/src/CKKS/Ciphertext.cuh
+++ b/src/CKKS/Ciphertext.cuh
@@ -6,6 +6,7 @@
 #define FIDESLIB_CKKS_CIPHERTEXT_CUH
 
 #include <source_location>
+#include <complex>
 #include "RNSPoly.cuh"
 #include "forwardDefs.cuh"
 #include "openfhe-interface/RawCiphertext.cuh"
@@ -211,6 +212,18 @@ class Ciphertext {
     void addScalar(const double c);
 
     /**
+     * @brief Adds a scalar (complex) to both polynomial components.
+     *
+     * The scalar is first converted to the appropriate modulus representation
+     * via `ElemForEvalAddOrSub`.  The sign of the scalar is handled by
+     * converting the element to its complement when `c < 0`.  No metadata
+     * updates are performed.
+     *
+     * @param c Scalar value to add.
+     */
+    void addScalar(const std::complex<double> c);
+
+    /**
      * @brief Multiplies *this* ciphertext by a plaintext.
      *
      * If the current rescaling technique requires matching noise levels,
@@ -313,6 +326,20 @@ class Ciphertext {
      * @param rescale Perform rescaling after multiplication if true.
      */
     void multScalar(const Ciphertext& b, const double c, bool rescale = false);
+
+    /**
+     * @brief Multiplies both polynomial components by a complex scalar, performing necessary checks.
+     *
+     * For flexible rescaling techniques the method may rescale the ciphertext
+     * when the noise level is 2.  The scalar is converted using
+     * `ElemForEvalMult` and the multiplication is applied to both components.
+     * Metadata (noise level/factor) is updated accordingly; if `rescale`
+     * is true and the technique is `FIXEDMANUAL`, a rescaling step follows.
+     *
+     * @param c Scalar multiplier.
+     * @param rescale Perform rescaling after multiplication if true.
+     */
+    void multScalar(const std::complex<double> c, bool rescale = false);
 
     /**
      * @brief Squares the ciphertext (i.e., multiplies it by itself).

--- a/src/CKKS/Context.cu
+++ b/src/CKKS/Context.cu
@@ -755,7 +755,7 @@ void ContextData::PrepareNCCLCommunication() {
             NCCLCHECK(
                 ncclCommRegister(GPUrank[g], top_limb_buffer2[i], sizeof(uint64_t) * N, &top_limb_buffer2_handle[i]));
 #else
-            cudaMalloc((void**)&top_limb_buffer[i], sizeof(uint63_t) * N);
+            cudaMalloc((void**)&top_limb_buffer[i], sizeof(uint64_t) * N);
             cudaMalloc((void**)&top_limb_buffer2[i], sizeof(uint64_t) * N);
 #endif
         } else {


### PR DESCRIPTION
- Addition to FIDESlib APIs for complex scalar addition and complex scalar multiplication.
- Added Complex CKKS datatype (must use in order to create plaintexts with complex values).
- Added scalar addition and multiplication to src/CKKS/Ciphertext.cpp.
- Scalar multiplication was tested and works fine, but scalar addition is buggy for negative real or imaginary components.
- GetLogPrecision() does not work when complex values are supported, based on what's in OpenFHE