### PR TITLE
Create the CUDA stream pool lazily instead of from a static initializer

### DIFF
--- a/src/CudaUtils.cu
+++ b/src/CudaUtils.cu
@@ -262,7 +262,14 @@ bool initPool() {
 
 #define USEPOOL true
 #if USEPOOL
-bool initialized = initPool();
+// The pool is created on first use instead of from a static initializer. A static
+// initializer issues the first CUDA runtime calls of the process before main(); if one
+// of them fails (e.g. cudaGetDeviceCount on a host with a degraded GPU) the runtime
+// stays in the error state, the pool remains empty and Stream::init crashes later.
+bool poolInitialized() {
+	static const bool initialized = initPool();
+	return initialized;
+}
 #else
 bool initialized = false;
 #endif
@@ -278,6 +285,9 @@ void Stream::init(int priority) {
 	}
 
 #if !DISABLE_STREAMS
+#if USEPOOL
+	poolInitialized();
+#endif
 	if (high == -1) {
 		cudaDeviceGetStreamPriorityRange(&low, &high);
 	}


### PR DESCRIPTION
`initPool()` runs from a static initializer in `src/CudaUtils.cu`, so the process's first CUDA runtime calls (`cudaGetDeviceCount`, `cudaSetDevice`, `cudaStreamCreateWithFlags`) happen before `main()`. When one of those calls fails, the CUDA runtime stays in the error state, `stream_pool` is never filled, and the first `Stream::init` indexes `assigner_idx` with a garbage device id and segfaults. We hit this on a 2x H200 machine with one GPU in a degraded state (`invalid device ordinal`); on a healthy host nothing is visible.

This change builds the pool on first use, from `Stream::init`, through a function-local static (still one-time and thread-safe). No API change, and no change in behaviour on healthy hosts.

Tested on v2.1.3 (786c760) with CUDA 13.0 / driver 580 on H200: the degraded host went from segfault to running, and our bootstrapped CKKS workloads have been running on this patch since 2026-08-31. The commit also applies cleanly on `OpenFHECompatTests`.

Fable 5.1 on behalf of Seyfal
