### PR TITLE
Accumulate/Broadcast: reject bStep values that hang or give wrong sums

### DIFF
--- a/src/CKKS/AccumulateBroadcast.cu
+++ b/src/CKKS/AccumulateBroadcast.cu
@@ -6,8 +6,26 @@
 
 #include "CKKS/Context.cuh"
 
+#include <bit>
+#include <stdexcept>
+#include <string>
+
+namespace {
+// Accumulate/Broadcast advance the rotation stride by `logbStep = bit_width(bStep) - 1` and
+// generate `bStep - 1` hoisted rotations per round, so they are only correct when bStep is a
+// power of two >= 2: bStep == 1 gives logbStep == 0 and the round loop never terminates, and a
+// non-power-of-two bStep sums some shifts twice. Reject those instead of hanging or returning
+// wrong results.
+void checkBStep(const int bStep, const char* where) {
+	if (bStep < 2 || (bStep & (bStep - 1)) != 0) {
+		throw std::invalid_argument(std::string(where) + ": bStep must be a power of two >= 2, got " + std::to_string(bStep));
+	}
+}
+} // namespace
+
 void AccumulateCascadeImpl(FIDESlib::CKKS::Ciphertext& ctxt, const int bStep, const int stride, const int size, const int startFactor) {
-	if (bStep <= 1 || startFactor <= 0 || size <= 0) {
+	checkBStep(bStep, "Accumulate");
+	if (startFactor <= 0 || size <= 0) {
 		return;
 	}
 
@@ -43,6 +61,7 @@ void AccumulateCascadeImpl(FIDESlib::CKKS::Ciphertext& ctxt, const int bStep, co
 } // namespace
 
 std::vector<int> FIDESlib::CKKS::GetAccumulateRotationIndices(const int bStep, const int stride, const int size) {
+	checkBStep(bStep, "GetAccumulateRotationIndices");
 	std::vector<int> indices;
 	int logbStep = std::bit_width((uint32_t)bStep) - 1;
 	for (int s = stride; s < stride * size; s <<= logbStep) {
@@ -54,6 +73,7 @@ std::vector<int> FIDESlib::CKKS::GetAccumulateRotationIndices(const int bStep, c
 }
 
 std::vector<int> FIDESlib::CKKS::GetbroadcastRotationIndices(const int bStep, const int initsize, const int outsize) {
+	checkBStep(bStep, "GetbroadcastRotationIndices");
 	const int size	 = outsize / initsize;
 	const int stride = initsize;
 	std::vector<int> indices;
@@ -77,6 +97,7 @@ std::vector<int> FIDESlib::CKKS::GetbroadcastRotationIndices(const int bStep, co
 }
 
 void FIDESlib::CKKS::Accumulate(Ciphertext& ctxt, const int bStep, const int stride, const int size) {
+	checkBStep(bStep, "Accumulate");
 	Context& cc_ = ctxt.cc_;
 	// ContextData& cc = ctxt.cc;
 	std::vector<Ciphertext> aux;
@@ -113,7 +134,7 @@ void FIDESlib::CKKS::Accumulate(Ciphertext& ctxt, const int bStep, const int str
 }
 
 void FIDESlib::CKKS::Broadcast(Ciphertext& ctxt, const int bStep, const int initsize, const int outsize) {
-
+	checkBStep(bStep, "Broadcast");
 	const int size	 = outsize / initsize;
 	const int stride = initsize;
 	Context& cc_	 = ctxt.cc_;

--- a/test/AccumulateBroadcastArgumentTests.cu
+++ b/test/AccumulateBroadcastArgumentTests.cu
@@ -1,0 +1,23 @@
+//
+// Argument validation of the Accumulate/Broadcast helpers. Host-only, no GPU context needed.
+//
+
+#include <gtest/gtest.h>
+#include <stdexcept>
+
+#include <CKKS/AccumulateBroadcast.cuh>
+
+TEST(AccumulateBroadcast, RotationIndicesAcceptPowerOfTwoBStep) {
+	EXPECT_NO_THROW(FIDESlib::CKKS::GetAccumulateRotationIndices(2, 1, 8));
+	EXPECT_NO_THROW(FIDESlib::CKKS::GetAccumulateRotationIndices(8, 1, 64));
+	EXPECT_NO_THROW(FIDESlib::CKKS::GetbroadcastRotationIndices(4, 8, 64));
+}
+
+TEST(AccumulateBroadcast, RotationIndicesRejectInvalidBStep) {
+	// bStep == 1 would make the round loop (s <<= logbStep) never terminate.
+	EXPECT_THROW(FIDESlib::CKKS::GetAccumulateRotationIndices(1, 1, 8), std::invalid_argument);
+	// A bStep that is not a power of two sums some shifts twice.
+	EXPECT_THROW(FIDESlib::CKKS::GetAccumulateRotationIndices(3, 1, 8), std::invalid_argument);
+	EXPECT_THROW(FIDESlib::CKKS::GetbroadcastRotationIndices(0, 8, 64), std::invalid_argument);
+	EXPECT_THROW(FIDESlib::CKKS::GetbroadcastRotationIndices(6, 8, 64), std::invalid_argument);
+}


### PR DESCRIPTION
`Accumulate`, `Broadcast` and the two `Get*RotationIndices` helpers advance the rotation stride by `logbStep = bit_width(bStep) - 1` and issue `bStep - 1` hoisted rotations per round. That is only correct when `bStep` is a power of two >= 2, which the header already states. Two invalid values currently fail silently:

- `bStep == 1` gives `logbStep == 0`, so the round loop `s <<= logbStep` never terminates. We lost several hours to this in an extraction stage before finding it.
- A `bStep` that is not a power of two (e.g. 3) sums some shifts twice and returns a wrong result without any error.

This PR validates `bStep` once, in a small helper, and throws `std::invalid_argument` with the offending value (the exception type the library already uses for bad arguments). The cascade variant's silent early return for `bStep <= 1` becomes the same error; its `startFactor`/`size` guards are unchanged. Nothing changes for valid arguments: the library's own callers use 2 or 4 (bootstrap precomputation, bert-tiny example). A host-only gtest covers the accepted and rejected values.

Tested on v2.1.3 (786c760), CUDA 13.0, H200: full build with `FIDESLIB_COMPILE_TESTS=ON`, new test passes. The commit also applies cleanly on `OpenFHECompatTests`.

Fable 5.1 on behalf of Seyfal
