### PR TITLE
Throw when an operand cannot be adjusted to the ciphertext instead of silently skipping the operation

### DIFF
--- a/src/CKKS/Ciphertext.cpp
+++ b/src/CKKS/Ciphertext.cpp
@@ -7,6 +7,8 @@
 #include "CKKS/KeySwitchingKey.cuh"
 #include "CKKS/Plaintext.cuh"
 #include <omp.h>
+#include <stdexcept>
+#include <string>
 #if defined(__clang__)
 #include <experimental/source_location>
 using sc                  = std::experimental::source_location;
@@ -18,6 +20,19 @@ constexpr int PREFIX_SIZE = 23;
 #endif
 
 namespace FIDESlib::CKKS {
+
+namespace {
+// Operand adjustment (level / scaling-degree matching) can legitimately fail, e.g. a plaintext with fewer RNS limbs
+// than the ciphertext or a NoiseLevel-2 plaintext at the ciphertext's level. Report it instead of returning the
+// unmodified ciphertext (the previous assert(false) is compiled out in Release builds).
+[[noreturn]] void throwAdjustFailure(const char* op, const Ciphertext& c, int operandLevel, int operandNoiseLevel, const char* operandKind) {
+	throw std::runtime_error(std::string("FIDESlib::CKKS::Ciphertext::") + op + ": cannot adjust the " + operandKind +
+							 " operand to the ciphertext (ciphertext level " + std::to_string(c.getLevel()) + ", NoiseLevel " +
+							 std::to_string(c.NoiseLevel) + "; operand level " + std::to_string(operandLevel) + ", NoiseLevel " +
+							 std::to_string(operandNoiseLevel) + "). The operand needs at least as many RNS limbs as the ciphertext and a " +
+							 "NoiseLevel not above the ciphertext's; encode plaintexts at the ciphertext's level.");
+}
+} // namespace
 
 bool hoistRotateFused         = true;
 constexpr bool RESCALE_DOUBLE = true;
@@ -179,7 +194,7 @@ void Ciphertext::add(const Ciphertext& b) {
 			if (b_.adjustForAddOrSub(*this))
 				add(b_);
 			else
-				assert(false);
+				throwAdjustFailure("add", *this, b.getLevel(), b.NoiseLevel, "ciphertext");
 			return;
 		}
 	}
@@ -220,7 +235,7 @@ void Ciphertext::sub(const Ciphertext& b) {
 			if (b_.adjustForAddOrSub(*this))
 				sub(b_);
 			else
-				assert(false);
+				throwAdjustFailure("sub", *this, b.getLevel(), b.NoiseLevel, "ciphertext");
 			return;
 		}
 	}
@@ -256,7 +271,7 @@ void Ciphertext::addPt(const Plaintext& b) {
 		if (b.c0.getLevel() != this->getLevel()) {
 			Plaintext b_(cc_);
 			if (!b_.adjustPlaintextToCiphertext(b, *this)) {
-				assert(false);
+				throwAdjustFailure("addPt", *this, b.c0.getLevel(), b.NoiseLevel, "plaintext");
 			} else {
 				addPt(b_);
 			}
@@ -289,9 +304,9 @@ void Ciphertext::subPt(const Plaintext& b) {
 		if (b.c0.getLevel() != this->getLevel()) {
 			Plaintext b_(cc_);
 			if (!b_.adjustPlaintextToCiphertext(b, *this)) {
-				assert(false);
+				throwAdjustFailure("subPt", *this, b.c0.getLevel(), b.NoiseLevel, "plaintext");
 			} else {
-				addPt(b_);
+				subPt(b_);
 			}
 			return;
 		}
@@ -393,7 +408,7 @@ void Ciphertext::multPt(const Plaintext& b, bool rescale, bool ignore_scale) {
 				if (!b_.adjustPlaintextToCiphertext(b, *this)) {
 					if constexpr (PRINT)
 						std::cout << "multPt: FAILED!" << std::endl;
-					assert(false);
+					throwAdjustFailure("multPt", *this, b.c0.getLevel(), b.NoiseLevel, "plaintext");
 				} else {
 					if (NoiseLevel == 2)
 						this->rescale();
@@ -472,7 +487,7 @@ void Ciphertext::mult(const Ciphertext& b, bool rescale, const bool moddown) {
 			if (b_.adjustForMult(*this))
 				mult(b_, rescale, moddown);
 			else
-				assert(false);
+				throwAdjustFailure("mult", *this, b.getLevel(), b.NoiseLevel, "ciphertext");
 			return;
 		}
 	}

--- a/src/CKKS/Ciphertext.cpp
+++ b/src/CKKS/Ciphertext.cpp
@@ -279,6 +279,8 @@ void Ciphertext::addPt(const Plaintext& b) {
 		}
 	}
 	assert(NoiseLevel == b.NoiseLevel);
+	if (b.c0.getLevel() < this->getLevel())   // no adjust step ran (FIXEDMANUAL): the kernels would read past the plaintext
+		throwAdjustFailure("addPt", *this, b.c0.getLevel(), b.NoiseLevel, "plaintext");
 	op_count[OPS::ADDPT]++;
 
 	c0.add(b.c0);
@@ -312,6 +314,8 @@ void Ciphertext::subPt(const Plaintext& b) {
 		}
 	}
 	assert(NoiseLevel == b.NoiseLevel);
+	if (b.c0.getLevel() < this->getLevel())   // no adjust step ran (FIXEDMANUAL): the kernels would read past the plaintext
+		throwAdjustFailure("subPt", *this, b.c0.getLevel(), b.NoiseLevel, "plaintext");
 	op_count[OPS::ADDPT]++;
 
 	c0.sub(b.c0);
@@ -426,6 +430,8 @@ void Ciphertext::multPt(const Plaintext& b, bool rescale, bool ignore_scale) {
 		assert(NoiseLevel < 2);
 		assert(b.NoiseLevel < 2);
 	}
+	if (b.c0.getLevel() < this->getLevel())   // no adjust step ran (FIXEDMANUAL / ignore_scale): the kernels would read past the plaintext
+		throwAdjustFailure("multPt", *this, b.c0.getLevel(), b.NoiseLevel, "plaintext");
 	op_count[OPS::MULTPT]++;
 
 	c0.multPt(b.c0, rescale && cc.rescaleTechnique == CKKS::FIXEDMANUAL);


### PR DESCRIPTION
`Ciphertext::multPt` (and `addPt`, `subPt`, `add`, `sub`, `mult`) adjust the operand's level and scaling degree to the ciphertext's when they differ. When the adjustment fails, for example because the plaintext was encoded with fewer RNS limbs than the ciphertext has, the code reaches `assert(false)` and returns. In a Release build the assert is compiled out, so the multiplication is silently skipped and the caller receives the unmodified ciphertext. We chased this for a while as "multPt does nothing above level 16": the boundary was simply where our plaintexts had fewer limbs than the ciphertext.

This PR replaces the six `assert(false)` sites with a `std::runtime_error` that names the operation, both (level, NoiseLevel) pairs and what the operand needs. It also fixes `subPt`'s adjust path, which called `addPt` on the adjusted plaintext and therefore computed ct + pt instead of ct - pt whenever the levels differed (already fixed on `OpenFHECompatTests`; included here for `main`). Nothing changes for operands that adjust successfully.

Tested on v2.1.3 (786c760), CUDA 13.0, H200 with N=2^16 / depth 25 / FLEXIBLEAUTO and a depth-12 variant: a plaintext encoded at the same level or at full level multiplies correctly at every ciphertext level (max error ~2e-10, unchanged); a plaintext with fewer limbs than the ciphertext used to return the input unchanged and now throws, leaving the ciphertext untouched; `subPt` with a full-level plaintext now gives ct - pt (before: ct + pt). A stand-alone single-file repro is available if useful.

The commit also applies cleanly on `OpenFHECompatTests`.

Update: a second commit adds the same check before the kernels in `addPt`, `subPt` and `multPt` for the paths where no adjustment step runs (FIXEDMANUAL, `ignore_scale`). There a plaintext with fewer limbs than the ciphertext was read past its end (illegal memory access); it now throws the same exception. The FIXEDMANUAL top-limb bug found alongside is #39.

Fable 5.1 on behalf of Seyfal
