### PR TITLE
Bootstrap: reject inputs with fewer limbs than their NoiseLevel needs instead of returning garbage

### DIFF
--- a/src/CKKS/Bootstrap.cu
+++ b/src/CKKS/Bootstrap.cu
@@ -9,6 +9,8 @@
 #include "CKKS/Ciphertext.cuh"
 #include "CKKS/CoeffsToSlots.cuh"
 #include "CKKS/Context.cuh"
+#include <stdexcept>
+#include <string>
 #if defined(__clang__)
 #include <experimental/source_location>
 using sc = std::experimental::source_location;
@@ -397,10 +399,21 @@ void FIDESlib::CKKS::ModRaise(Ciphertext& ctxt, const int slots, const uint32_t 
 	// RAISING THE MODULUS
 	//------------------------------------------------------------------------------
 
+	// Input precondition. This used to be an assert(), i.e. absent from Release builds: the modulus raise below first
+	// consumes the pending rescale of a NoiseLevel-2 input and then one more limb (multScalar + rescale before
+	// dropToLevel(0)), so the input needs level >= NoiseLevel (NoiseLevel 1: level >= 1, NoiseLevel 2: level >= 2).
+	// Otherwise rescale() runs on a single-limb polynomial and the result is silently garbage/NaN (or a crash).
 	if (!prescaled) {
-		assert(ctxt.getLevel() - ctxt.NoiseLevel + 1 >= 1);
+		if (ctxt.getLevel() < ctxt.NoiseLevel) {
+			throw std::invalid_argument("FIDESlib::CKKS::Bootstrap: ciphertext at level " + std::to_string(ctxt.getLevel()) + " with NoiseLevel " +
+			  std::to_string(ctxt.NoiseLevel) + " cannot be bootstrapped: the modulus raise requires level >= NoiseLevel, i.e. level >= " +
+			  std::to_string(ctxt.NoiseLevel) + " for this input (rescale() a NoiseLevel-2 ciphertext or keep one more limb).");
+		}
 	} else {
-		assert(ctxt.getLevel() - ctxt.NoiseLevel + 1 == 0);
+		if (ctxt.getLevel() - ctxt.NoiseLevel + 1 != 0) {
+			throw std::invalid_argument("FIDESlib::CKKS::Bootstrap(prescaled = true): expected level == NoiseLevel - 1, got level " +
+			  std::to_string(ctxt.getLevel()) + " and NoiseLevel " + std::to_string(ctxt.NoiseLevel) + ".");
+		}
 	}
 	// In FLEXIBLEAUTO, raising the ciphertext to a larger number
 	// of towers is a bit more complex, because we need to adjust

--- a/src/CKKS/Bootstrap.cuh
+++ b/src/CKKS/Bootstrap.cuh
@@ -14,7 +14,17 @@ void BootstrapCPUraise(Ciphertext& ctxt,
   std::shared_ptr<lbcrypto::CryptoContextImpl<lbcrypto::DCRTPolyImpl<bigintdyn::mubintvec<bigintdyn::ubint<expdtype>>>>>& CPUcc,
   lbcrypto::KeyPair<lbcrypto::DCRTPoly> keys,
   const bool prescaled);
-// void Bootstrap(Ciphertext& ctxt, const int slots, const bool prescaled = false);
+/**
+ * @brief Bootstraps `ctxt` in place (refreshes its level budget).
+ *
+ * @pre ctxt.getLevel() >= ctxt.NoiseLevel (levels count RNS limbs minus one): a NoiseLevel-1 input needs at least
+ *      two limbs (level >= 1) and a NoiseLevel-2 input (pending rescale) at least three (level >= 2), because the
+ *      modulus raise rescales once (twice for NoiseLevel 2) before raising. With `prescaled == true` the input must
+ *      instead satisfy level == NoiseLevel - 1. Violations throw std::invalid_argument.
+ * @param ctxt      Ciphertext to bootstrap; on return it is at the post-bootstrap level with NoiseLevel 1.
+ * @param slots     Number of slots the bootstrap precomputation was generated for (>= ctxt.slots).
+ * @param prescaled Whether the caller already applied the modulus-raise prescaling.
+ */
 void Bootstrap(Ciphertext& ctxt, const int slots, const bool prescaled = false);
 double GetPreScaleFactor(Context& cc, int slots);
 void ModRaise(Ciphertext& ctxt, const int slots, const uint32_t correction, const bool prescaled = false, bool sparse_encaps = false);


### PR DESCRIPTION
`Bootstrap()` on a ciphertext at level 1 with NoiseLevel 2, or at level 0 with NoiseLevel 1, runs to completion without any error and returns a ciphertext at the normal post-bootstrap level, but the content is noise (OpenFHE's `Decrypt` reports "the approximation error is too high"). Level 2 / NoiseLevel 2 and level 1 / NoiseLevel 1 bootstrap correctly.

Cause: `ModRaise` (`src/CKKS/Bootstrap.cu`) checks `getLevel() - NoiseLevel + 1 >= 1` only with `assert()`, which is compiled out in Release builds. The raise then consumes the pending rescale of a NoiseLevel-2 input and one more limb (`multScalar` + `rescale` before `dropToLevel(0)`), so an input with fewer limbs than that rescales a single-limb polynomial (`LimbPartition::rescale`'s own `assert(limbsize > 1)` is compiled out too) and the raise works on a level -1 ciphertext.

This PR turns the check into a real one: `std::invalid_argument` naming the level, the NoiseLevel and the required minimum (level >= NoiseLevel; for `prescaled == true`, level == NoiseLevel - 1), and documents the precondition on `Bootstrap()` in `Bootstrap.cuh`. Valid inputs are unchanged.

Tested on v2.1.3 (786c760), CUDA 13.0, H200 with N=2^16 / depth 25 / scaleModSize 52 / firstModSize 56 / 3 digits / FLEXIBLEAUTO / UNIFORM_TERNARY / 16384 slots, with the `examples/bootstrap` parameters (N=2^12, full slots) and with the UNIFORM bootstrap configuration: the two bad cases (level 1 / NoiseLevel 2, level 0 / NoiseLevel 1) went from silent garbage to the exception; the three good cases are unchanged (max error 2.0e-3 to 2.2e-3 at our parameters, 3e-5 at the example parameters).

The commit also applies cleanly on `OpenFHECompatTests`.

Fable 5.1 on behalf of Seyfal
