### PR TITLE
rotate_hoisted: copy slots to results in the non-fused path; document ext

### DIFF
--- a/src/CKKS/Ciphertext.cpp
+++ b/src/CKKS/Ciphertext.cpp
@@ -1007,9 +1007,7 @@ void Ciphertext::rotate_hoisted(const std::vector<int>& indexes_, std::vector<Ci
 					// if (!ext)
 					//     results[i]->c0.moddown(true, false);
 
-					results[i]->keyID       = keyID;
-					results[i]->NoiseLevel  = NoiseLevel;
-					results[i]->NoiseFactor = NoiseFactor;
+					results[i]->copyMetadata(*this); // also copies `slots` (was keyID/NoiseLevel/NoiseFactor only -> slots stayed 0)
 				}
 			}
 		} else {

--- a/src/CKKS/Ciphertext.cuh
+++ b/src/CKKS/Ciphertext.cuh
@@ -449,7 +449,14 @@ class Ciphertext {
 	 *
 	 * @param indexes Vector of rotation indexes.
 	 * @param results Vector to receive resulting ciphertext pointers.
-	 * @param ext     If true, extends ciphertexts before rotation.
+	 * @param ext     If true, the results are left in the extended Q*P basis
+	 *                (isModUp() == true, values scaled by P) so that several of
+	 *                them can be added and brought back with a single moddown().
+	 *                Such results are not valid inputs for any other operation
+	 *                (rescale, multPt, store, ...) until they, or the sum they
+	 *                were added into, have been moddown'ed; see Accumulate() for
+	 *                the intended pattern. If false, each result is moddown'ed
+	 *                and ready to use.
 	 */
 	void rotate_hoisted(const std::vector<int>& indexes, std::vector<Ciphertext*> results, bool ext);
 


### PR DESCRIPTION
`Ciphertext::rotate_hoisted` has three code paths. The fused and multi-GPU paths copy all metadata to the results with `copyMetadata(*this)`; the non-fused single-GPU path (`Ciphertext.cpp`, around line 1010) only sets `keyID`, `NoiseLevel` and `NoiseFactor`. A result that was constructed fresh therefore keeps `slots == 0`. Storing and decrypting such a result makes OpenFHE's `CKKSPackedEncoding::Decode` divide by zero (SIGFPE), and a later `rotate()` on it reduces the index modulo 0. This PR uses `copyMetadata(*this)` in the non-fused path too. Values are unchanged; only the metadata is.

It also documents the `ext` parameter in `Ciphertext.cuh`. With `ext == true` the results are left in the extended Q*P basis (`isModUp() == true`), which is what lets `Accumulate()` add several rotations and pay for one `moddown()`. The header only said "extends ciphertexts before rotation", and we spent a while treating those results as ordinary ciphertexts before finding the rule in the `Accumulate` code.

Tested on an H200 with N = 2^16, 16384 slots: rotate_hoisted with `ext = false` and `ext = true` (added, then one moddown) both decrypt to the exact rotation at every level 25 down to 1, before and after the patch; the `slots == 0` symptom disappears with the patch. The commit also applies cleanly on `OpenFHECompatTests`.

Fable 5.1 on behalf of Seyfal
