### PR TITLE
LimbPartition::multPt: use the top limb of the current level (FIXEDMANUAL multPt with rescale was wrong below the top level)

### DIFF
--- a/src/CKKS/LimbPartition.cu
+++ b/src/CKKS/LimbPartition.cu
@@ -662,13 +662,16 @@ void LimbPartition::multPt(const LimbPartition& p) {
 	static std::map<int, cudaGraphExec_t> exec_map;
 
 	{
-		LimbImpl& top = limb.back();
+		// The storage vector may hold more limbs than the current level (limbs are never popped by rescale/dropToLevel and
+		// polys are recycled through the auxiliary-poly pool); the top limb of the CURRENT level is limb[limbsize - 1], as in
+		// LimbPartition::rescale and in the fused NTT_MULTPT kernel below (ApplyNTT receives limbsize from NTT()).
+		LimbImpl& top = limb.at(limbsize - 1);
 
 		cudaGraphExec_t& exec = exec_map[limbsize];
 
 		run_in_graph<capture>(exec, s, [&]() {
 			STREAM(top).wait(s);
-			SWITCH(top, mult(p.limb.back()));
+			SWITCH(top, mult(p.limb.at(limbsize - 1)));
 			SWITCH(top, INTT<ALGO_SHOUP>());
 
 			for (int32_t i = 0; i < limbsize - 1; i += cc.batch) {

--- a/src/CKKS/LimbPartition.cu
+++ b/src/CKKS/LimbPartition.cu
@@ -662,9 +662,6 @@ void LimbPartition::multPt(const LimbPartition& p) {
 	static std::map<int, cudaGraphExec_t> exec_map;
 
 	{
-		// The storage vector may hold more limbs than the current level (limbs are never popped by rescale/dropToLevel and
-		// polys are recycled through the auxiliary-poly pool); the top limb of the CURRENT level is limb[limbsize - 1], as in
-		// LimbPartition::rescale and in the fused NTT_MULTPT kernel below (ApplyNTT receives limbsize from NTT()).
 		LimbImpl& top = limb.at(limbsize - 1);
 
 		cudaGraphExec_t& exec = exec_map[limbsize];


### PR DESCRIPTION
`LimbPartition::multPt` takes `limb.back()` and `p.limb.back()` for the multiply + INTT of the top limb, while the fused NTT_MULTPT launch it feeds is given `limbsize = getLimbSize(*level)` and base-converts from `limb[limbsize - 1]`. The two differ whenever the storage vector holds more limbs than the current level, which is the normal state: `dropToLevel` and `rescale` never pop limbs and polys are recycled through the auxiliary pool. `LimbPartition::rescale` itself already uses `limb.at(limbsize - 1)`.

Effect: with `SetScalingTechnique(FIXEDMANUAL)`, `ct.multPt(pt, true)` decrypts correctly only for a ciphertext at the top level (N = 2^16, depth 25: level 24, error 3.2e-10). At levels 20, 17, 16, 15, 14, 13, 12, 10 and 5 the result is garbage (OpenFHE's decode gate fires). `multPt(pt, false)` followed by `rescale()` is correct at all levels, and FLEXIBLEAUTO is not affected. With this two-line change, `multPt(pt, true)` is correct at every level 5..24 (3.4e-10 .. 3.5e-9), tested on an H200.

Related: #36 now also checks the plaintext limb count before the kernels, because under FIXEDMANUAL no adjustment step runs and a short plaintext was read out of bounds.

Fable 5.1 on behalf of Seyfal
