### PR TITLE
clearAuxilarPoly: synchronize once instead of recording an event per pooled buffer

### DIFF
--- a/src/CKKS/Context.cu
+++ b/src/CKKS/Context.cu
@@ -18,6 +18,10 @@ using sc = std::experimental::source_location;
 using sc = std::source_location;
 #endif
 
+namespace FIDESlib {
+extern thread_local bool gpufree_presynced;   // defined in CudaUtils.cu next to GPUfree
+}
+
 namespace FIDESlib::CKKS {
 
 std::atomic_uint64_t next_uid = 0;
@@ -923,7 +927,14 @@ void ContextData::trimAuxilarPoly(size_t size) {
 }
 
 void ContextData::clearAuxilarPoly() {
+	// The pool can hold hundreds of RNSPolys with tens of pooled limb buffers each. Every pooled free records an event on
+	// the freeing stream and makes the pool stream wait on it, so a clear costs thousands of event operations (nsys, H200,
+	// N = 2^16, 104 polys: 4816 cudaEventRecord + 4816 cudaStreamWaitEvent, 12.6 ms of host time). After one device-wide
+	// synchronize no buffer is in use any more, so those waits are redundant: skip them while the pool is being cleared.
+	cudaDeviceSynchronize();
+	FIDESlib::gpufree_presynced = true;
 	precom.auxPoly.clear();
+	FIDESlib::gpufree_presynced = false;
 }
 
 void ContextData::clearAutomorphismKeys(const KeyHash& KeyID) {

--- a/src/CudaUtils.cu
+++ b/src/CudaUtils.cu
@@ -459,6 +459,8 @@ void CUDART_CB streamCallback(void* userData) {
 	delete p;
 }
 
+thread_local bool gpufree_presynced = false;
+
 void GPUfree(void* ptr, int id, int bytes, cudaStream_t stream, bool cache) {
 
 	if (bytes < 64 * 1024) {
@@ -481,7 +483,8 @@ void GPUfree(void* ptr, int id, int bytes, cudaStream_t stream, bool cache) {
 		CudaCheckErrorModNoSync;
 		// cudaDeviceSynchronize();
 		//if (stream != nullptr) {
-		s[id].wait(stream);
+		if (!gpufree_presynced)   // redundant while ContextData::clearAuxilarPoly holds the device synchronized
+			s[id].wait(stream);
 		//}
 		CudaCheckErrorModNoSync;
 		mempool_lock[id].lock();


### PR DESCRIPTION
## What

`ContextData::clearAuxilarPoly()` now synchronizes the device once and then lets `GPUfree` skip the per-buffer "pool stream waits for the freeing stream" event pair while the pool is being destroyed.

## Why

Every pooled limb buffer freed through `GPUfree` records an event on the freeing stream and makes the memory-pool stream wait on it (`s[id].wait(stream)` in `CudaUtils.cu`). Clearing the auxiliary-polynomial pool destroys every pooled `RNSPoly` at once, so a clear costs thousands of those event operations even though nothing is in flight any more.

Measured with Nsight Systems on an H200 (CUDA 12, N = 2^16, 25-limb chain, pool of 104 polynomials, one clear per MoE layer):

| | before | after |
|---|---|---|
| event operations per clear | 4816 `cudaEventRecord` + 4816 `cudaStreamWaitEvent` | 0 (+1 `cudaDeviceSynchronize`) |
| host time of the clear (median of 64 layers, unprofiled sub-timer) | 12.0 ms (12.6 ms in the traced run) | 0.6 ms |
| pipeline stage that contains the clear (median of 64 layers) | 49.8 ms | 41.4 ms |

The rest of the clear is the ~100 `LimbPartition` destructors and the pool bookkeeping itself.

## Why it is safe

After `cudaDeviceSynchronize()` returns, no stream can still be using a buffer that is about to be returned to the pool, which is exactly what the skipped event pair was protecting against. The flag is `thread_local` and is set only for the duration of `precom.auxPoly.clear()`, so frees issued from other threads keep their waits.

Validation: a 32-layer CKKS MoE chain (N = 2^16, depth 25, one `clearAuxilarPoly` per layer, 16384 and 32768 slots) passes its regression gates with the change in four independent runs (expert routing 32/32 layers, output error class, noise band), and the per-stage timings of everything except the stage containing the clear are unchanged to 0.1 ms.

## Notes

`clearAuxilarPoly` is a coarse operation (callers use it between layers or at shutdown), so one device-wide synchronize inside it is a reasonable price. If you would rather keep the old behaviour available, the flag could be gated behind a parameter; happy to adjust.

Fable 5.1 on behalf of Seyfal
