### PR TITLE
Fix: GPU compatibility for V100, with CUDA 12.x and sm_70.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,7 @@ build/
 deps/openfhe-src/
 
 .cache/
+
+__pycache__/
+*.pyc
+build-*/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,8 +4,69 @@ cmake_policy(VERSION 3.21.3...3.30)
 ############### Project configuration ###################
 
 # Set target architectures.
+#
+# FIDESLIB_ARCH (semicolon list, CMake CUDA_ARCHITECTURES syntax) can be given explicitly.
+# Otherwise it is derived from (a) the GPUs visible through nvidia-smi and (b) the CUDA
+# toolkit version, so that e.g. a V100 (sm_70) builds on CUDA 12.x while CUDA 13 (which
+# dropped sm_70) and older toolkits (which lack sm_100/120) do not fail with an unknown
+# architecture. Pass -DFIDESLIB_ARCH=70-real to force a specific target.
+set(_fideslib_all_archs "80-real;86-real;89-real;90-real;90-virtual;100-real;120-real")
 if (NOT DEFINED FIDESLIB_ARCH)
-    set(FIDESLIB_ARCH "80-real;86-real;89-real;90-real;90-virtual;100-real;120-real" CACHE STRING "Set the backend architecture target.")
+    if (NOT DEFINED CUDA_PATH)
+        set(CUDA_PATH "/usr/local/cuda")
+    endif ()
+    # nvcc version -> supported SM range.
+    set(_nvcc_major 12)
+    set(_nvcc_minor 0)
+    execute_process(COMMAND "${CUDA_PATH}/bin/nvcc" --version OUTPUT_VARIABLE _nvcc_out ERROR_QUIET RESULT_VARIABLE _nvcc_rc)
+    if (_nvcc_rc EQUAL 0 AND _nvcc_out MATCHES "release ([0-9]+)\\.([0-9]+)")
+        set(_nvcc_major ${CMAKE_MATCH_1})
+        set(_nvcc_minor ${CMAKE_MATCH_2})
+    endif ()
+    set(_min_sm 70)
+    set(_max_sm 90)
+    if (_nvcc_major GREATER_EQUAL 13)
+        set(_min_sm 75)   # CUDA 13 removed Volta (sm_70).
+    endif ()
+    if (_nvcc_major GREATER 12 OR (_nvcc_major EQUAL 12 AND _nvcc_minor GREATER_EQUAL 8))
+        set(_max_sm 120)  # sm_100/sm_120 need CUDA >= 12.8.
+    endif ()
+    # Detect the GPUs actually present.
+    set(_detected "")
+    find_program(_nvidia_smi nvidia-smi)
+    if (_nvidia_smi)
+        execute_process(COMMAND "${_nvidia_smi}" --query-gpu=compute_cap --format=csv,noheader OUTPUT_VARIABLE _smi_out ERROR_QUIET RESULT_VARIABLE _smi_rc)
+        if (_smi_rc EQUAL 0)
+            string(REPLACE "\n" ";" _caps "${_smi_out}")
+            foreach (_cap IN LISTS _caps)
+                string(STRIP "${_cap}" _cap)
+                if (_cap MATCHES "^([0-9]+)\\.([0-9]+)$")
+                    math(EXPR _sm "${CMAKE_MATCH_1} * 10 + ${CMAKE_MATCH_2}")
+                    if (_sm GREATER_EQUAL _min_sm AND _sm LESS_EQUAL _max_sm)
+                        list(APPEND _detected "${_sm}-real")
+                    else ()
+                        message(WARNING "GPU compute capability ${_cap} is outside what nvcc ${_nvcc_major}.${_nvcc_minor} supports (sm_${_min_sm}..sm_${_max_sm}); skipping it. Install a matching CUDA toolkit or set FIDESLIB_ARCH.")
+                    endif ()
+                endif ()
+            endforeach ()
+            list(REMOVE_DUPLICATES _detected)
+        endif ()
+    endif ()
+    if (_detected)
+        set(FIDESLIB_ARCH "${_detected}" CACHE STRING "Set the backend architecture target.")
+        message(STATUS "FIDESlib: CUDA architectures auto-detected from nvidia-smi: ${FIDESLIB_ARCH}")
+    else ()
+        # No GPU visible at configure time: build the generic list clipped to what this nvcc accepts.
+        set(_clipped "")
+        foreach (_a IN LISTS _fideslib_all_archs)
+            string(REGEX MATCH "^([0-9]+)" _sm "${_a}")
+            if (_sm GREATER_EQUAL _min_sm AND _sm LESS_EQUAL _max_sm)
+                list(APPEND _clipped "${_a}")
+            endif ()
+        endforeach ()
+        set(FIDESLIB_ARCH "${_clipped}" CACHE STRING "Set the backend architecture target.")
+        message(STATUS "FIDESlib: no GPU detected at configure time; CUDA architectures: ${FIDESLIB_ARCH}")
+    endif ()
 endif ()
 
 # Set build type.

--- a/api/CryptoContext.cpp
+++ b/api/CryptoContext.cpp
@@ -130,8 +130,10 @@ CryptoContextImpl<DCRTPoly>::~CryptoContextImpl() {
 		FIDESlib::CKKS::DeregisterCryptoContextGPU(context_gpu);
 		this->gpu = std::any();
 	}
-	lbcrypto::CryptoContextImpl<lbcrypto::DCRTPolyImpl<bigintdyn::mubintvec<bigintdyn::ubint<unsigned long>>>>::ClearEvalMultKeys();
-	lbcrypto::CryptoContextImpl<lbcrypto::DCRTPolyImpl<bigintdyn::mubintvec<bigintdyn::ubint<unsigned long>>>>::ClearEvalAutomorphismKeys();
+	// Deliberately does NOT call ClearEvalMultKeys() / ClearEvalAutomorphismKeys(): those no-argument
+	// overloads wipe OpenFHE's *global* static key maps, i.e. every other context's keys as well.
+	// OpenFHE's own CryptoContextImpl has no such destructor. Callers who want the host key memory back
+	// can use the per-context overloads ClearEvalMultKeys(cc) / ClearEvalAutomorphismKeys(cc).
 }
 
 // ---- Enable features ----
@@ -1092,7 +1094,6 @@ Ciphertext<DCRTPoly> CryptoContextImpl<DCRTPoly>::EvalSub(double scalar, const C
 	auto res_gpu                = std::static_pointer_cast<FIDESlib::CKKS::Ciphertext>(this->GetDeviceCiphertext(result->gpu));
 	res_gpu->multScalar(-1.0);
 	res_gpu->addScalar(scalar);
-	res_gpu->multScalar(-1.0);
 
 	return result;
 }
@@ -1217,7 +1218,7 @@ Ciphertext<DCRTPoly> CryptoContextImpl<DCRTPoly>::EvalMult(const Ciphertext<DCRT
 
 		auto& context                   = std::any_cast<const lbcrypto::CryptoContext<lbcrypto::DCRTPoly>&>(this->cpu);
 		auto& ct1Impl                   = std::any_cast<const lbcrypto::Ciphertext<lbcrypto::DCRTPoly>&>(ct1->cpu);
-		auto& ptImpl                    = std::any_cast<const lbcrypto::ConstPlaintext&>(pt->cpu);
+		auto& ptImpl                    = std::any_cast<const lbcrypto::Plaintext&>(pt->cpu);
 		auto ct                         = context->EvalMult(ct1Impl, ptImpl);
 		Ciphertext<DCRTPoly> ciphertext = std::make_shared<CiphertextImpl<DCRTPoly>>(this->self_reference.lock());
 		ciphertext->cpu                 = std::make_any<lbcrypto::Ciphertext<lbcrypto::DCRTPoly>>(ct);
@@ -1278,7 +1279,7 @@ void CryptoContextImpl<DCRTPoly>::EvalMultInPlace(Ciphertext<DCRTPoly>& ct1, Pla
 		auto& context = std::any_cast<const lbcrypto::CryptoContext<lbcrypto::DCRTPoly>&>(this->cpu);
 		EnsureMutableCpuCiphertext(ct1);
 		auto& ct1Impl = std::any_cast<lbcrypto::Ciphertext<lbcrypto::DCRTPoly>&>(ct1->cpu);
-		auto& ptImpl  = std::any_cast<const lbcrypto::ConstPlaintext&>(pt->cpu);
+		auto& ptImpl  = std::any_cast<const lbcrypto::Plaintext&>(pt->cpu);
 		auto res      = context->EvalMult(ct1Impl, ptImpl);
 		ct1->cpu      = std::make_any<lbcrypto::Ciphertext<lbcrypto::DCRTPoly>>(res);
 		return;

--- a/src/CKKS/Ciphertext.cpp
+++ b/src/CKKS/Ciphertext.cpp
@@ -2,6 +2,7 @@
 // Created by carlosad on 24/04/24.
 //
 
+#include <stdexcept>
 #include "CKKS/Ciphertext.cuh"
 #include "CKKS/Context.cuh"
 #include "CKKS/KeySwitchingKey.cuh"
@@ -1635,12 +1636,26 @@ void Ciphertext::multMonomial(/*Ciphertext& ctxt,*/ int power) {
 		monomial.dropToLevel(c0.getLevel());
 		std::vector<uint64_t> coefs(cc.N, 0);
 
+		// `limb` must actually hold every limb the level claims. RNSPoly::grow returns early when the
+		// pooled polynomial is already at or above the target level, so a mismatch here is possible in
+		// principle, and the consequence is not a clean failure: `g.limb[i]` past the end hands the
+		// kernel a garbage device pointer, and the illegal access surfaces at whatever synchronises
+		// next - typically a GPUfree several calls later, which is where it was first reported from a
+		// GV100. Check it where it is cheap and say so where it is meaningful.
+		const auto checkLimbs = [](const LimbPartition& g, int limb_size) {
+			if ((size_t)limb_size > g.limb.size())
+				throw std::runtime_error("FIDESlib: multMonomial found " + std::to_string(g.limb.size()) +
+										 " limbs where the polynomial's level requires " + std::to_string(limb_size) +
+										 ". The auxiliary polynomial was not grown to its own level.");
+		};
+
 		if (power < cc.N) {
 			coefs[power] = 1;
 
 			for (auto& g : monomial.GPU) {
 				cudaSetDevice(g.device);
 				int limb_size = g.getLimbSize(monomial.getLevel());
+				checkLimbs(g, limb_size);
 				for (int i = 0; i < limb_size; ++i) {
 					SWITCH(g.limb[i], load(coefs));
 					g.s.wait(STREAM(g.limb[i]));
@@ -1659,6 +1674,7 @@ void Ciphertext::multMonomial(/*Ciphertext& ctxt,*/ int power) {
 			for (auto& g : monomial.GPU) {
 				cudaSetDevice(g.device);
 				int limb_size = g.getLimbSize(monomial.getLevel());
+				checkLimbs(g, limb_size);
 				for (int i = 0; i < limb_size; ++i) {
 					coefs[power % cc.N] = (cc.prime[PRIMEID(g.limb[i])].p - 1) /*% ctxt.cc.prime[PRIMEID(l)].p*/;
 					SWITCH(g.limb[i], load(coefs));

--- a/src/CKKS/CoeffsToSlots.cu
+++ b/src/CKKS/CoeffsToSlots.cu
@@ -96,7 +96,31 @@ void FIDESlib::CKKS::EvalCoeffsToSlots(Ciphertext& ctxt, int slots, bool decode)
 	if (ctxt.NoiseLevel == 2)
 		ctxt.rescale();
 
-	for (BootstrapPrecomputation::LTstep& step : (decode ? cc.GetBootPrecomputation(slots).StC : cc.GetBootPrecomputation(slots).CtS)) {
+	auto& steps = decode ? cc.GetBootPrecomputation(slots).StC : cc.GetBootPrecomputation(slots).CtS;
+
+	// The diagonals come from OpenFHE's EvalBootstrapSetup, which encodes them at a level of its own
+	// choosing, while ModRaise here grows the ciphertext to `cc.L` (minus one only for
+	// FLEXIBLEAUTOEXT). Under FIXEDMANUAL those disagree by a limb, and the batched product does not
+	// tolerate that the way OpenFHE's EvalMult(ct, pt) does - it sizes the launch from the ciphertext
+	// and indexes the plaintext with the same bound, so the kernel reads one limb past the end.
+	// Observed on a GV100 as "would read 35 limbs from pt[0], which holds 34".
+	//
+	// Drop the ciphertext to the diagonals of the step about to run, which is what OpenFHE's
+	// AdjustLevelsAndDepth does implicitly. Done per step rather than once, because each layer has its
+	// own diagonals and its own level.
+	const auto alignToDiagonals = [](Ciphertext& ct, const BootstrapPrecomputation::LTstep& step) {
+		int ptLevel = -1;
+		for (const Plaintext& pt : step.A) {
+			const int level = pt.c0.getLevel();
+			if (level >= 0 && (ptLevel < 0 || level < ptLevel))
+				ptLevel = level;
+		}
+		if (ptLevel >= 0 && ct.getLevel() > ptLevel)
+			ct.dropToLevel(ptLevel);
+	};
+
+	for (BootstrapPrecomputation::LTstep& step : steps) {
+		alignToDiagonals(ctxt, step);
 		// computes the NTTs for each CRT limb (for the hoisted automorphisms used later on)
 
 		if constexpr (BATCHED) {

--- a/src/CKKS/Context.cu
+++ b/src/CKKS/Context.cu
@@ -1028,8 +1028,8 @@ void AddSecretSwitchingKey(KeySwitchingKey&& ksk_a, KeySwitchingKey&& ksk_b) {
 
 	KeyHash id_a        = ksk_a.keyID;
 	KeyHash id_b        = ksk_b.keyID;
-	Parameters& param_a = ksk_a.cc->param;
-	Parameters& param_b = ksk_b.cc->param;
+	Parameters& param_a = ksk_a.context()->param;
+	Parameters& param_b = ksk_b.context()->param;
 
 	{
 		std::pair<std::pair<Parameters, Parameters>, std::unique_ptr<std::map<KeyHash, KeySwitchingKey>>>* entry = nullptr;

--- a/src/CKKS/KeySwitchingKey.cu
+++ b/src/CKKS/KeySwitchingKey.cu
@@ -19,6 +19,7 @@ using sc = std::source_location;
 namespace FIDESlib::CKKS {
 void KeySwitchingKey::Initialize(RawKeySwitchKey& rkk) {
 	CudaNvtxRange r(std::string{ sc::current().function_name() }.substr());
+	Context cc = context();
 	CKKS::SetCurrentContext(cc);
 	keyID = rkk.keyid;
 
@@ -35,7 +36,7 @@ void KeySwitchingKey::Initialize(RawKeySwitchKey& rkk) {
 }
 
 KeySwitchingKey::KeySwitchingKey(Context& cc)
-: my_range(loc, LIFETIME), keyID(""), cc((assert(cc != nullptr), CudaNvtxStart(std::string{ sc::current().function_name() }.substr()), cc)),
+: my_range(loc, LIFETIME), keyID(""), cc_weak((assert(cc != nullptr), CudaNvtxStart(std::string{ sc::current().function_name() }.substr()), cc)),
   a(*cc, -1, false, true), b(*cc, -1, false, true) {
 	CudaNvtxStop();
 	/*

--- a/src/CKKS/KeySwitchingKey.cuh
+++ b/src/CKKS/KeySwitchingKey.cuh
@@ -5,7 +5,9 @@
 #ifndef GPUCKKS_KEYSWITCHINGKEY_CUH
 #define GPUCKKS_KEYSWITCHINGKEY_CUH
 
+#include <cassert>
 #include <cinttypes>
+#include <memory>
 #include <vector>
 
 #include "RNSPoly.cuh"
@@ -20,7 +22,27 @@ class KeySwitchingKey {
 
   public:
 	KeyHash keyID;
-	Context& cc;
+	/**
+	 * Non-owning, and deliberately neither a reference nor a shared_ptr.
+	 *
+	 * A `Context&` member dangles: CryptoContextImpl::LoadContext moves its local Context into a
+	 * std::any, so the referent dies when LoadContext returns. Holding a `Context` by value fixes
+	 * that but closes a reference cycle, because keys live inside ContextData::precom.keys: the
+	 * ContextData can then never reach zero references, and every context dropped through the API
+	 * keeps all of its device memory - eval and rotation keys, bootstrap plaintexts, auxiliary
+	 * buffers - for the life of the process.
+	 *
+	 * A weak_ptr fixes the dangling reference without owning the object this key is a member of.
+	 * It cannot expire while the key is alive, for exactly that reason, and context() asserts it.
+	 */
+	std::weak_ptr<ContextData> cc_weak;
+
+	/** The context this key belongs to. Every use is a read of one of its fields. */
+	[[nodiscard]] Context context() const {
+		Context cc = cc_weak.lock();
+		assert(cc != nullptr);
+		return cc;
+	}
 	RNSPoly a;
 	RNSPoly b;
 	// std::vector<RNSPoly> mgpu_a;

--- a/src/CKKS/LimbPartitionBatch.cu
+++ b/src/CKKS/LimbPartitionBatch.cu
@@ -1,6 +1,7 @@
 //
 // Created by carlosad on 1/10/25.
 //
+#include <stdexcept>
 #include <algorithm>
 #include <array>
 #include <variant>
@@ -309,6 +310,30 @@ void LimbPartition::LTdotProductPtBatch(std::vector<LimbPartition*>& out,
 
 	dim3 sgrid = grid;
 	sgrid.y	   = slimbsize;
+
+	// The launch is sized `grid.y = limbsize`, taken from out[0]'s level, and the kernel reaches
+	// `pt_partition[blockIdx.y]` after checking only that `pt_partition` itself is non-null. So a
+	// partition that *is* present but holds fewer limbs than out[0]'s level implies gives the kernel a
+	// pointer past the end of that limb vector, and the resulting illegal access surfaces at whatever
+	// synchronises next. The plaintexts are the operand most likely to disagree, being precomputed at
+	// a level of their own.
+	//
+	// A null `pt` entry is NOT an error: DotProductPtInternal pushes nullptr for a diagonal that has no
+	// plaintext, the device pointer table carries it through, and the kernel skips those terms. An
+	// earlier version of this check rejected them and aborted a bootstrap that was working.
+	const auto checkLimbs = [limbsize](const std::vector<LimbPartition*>& v, const char* what) {
+		for (size_t k = 0; k < v.size(); ++k) {
+			if (v[k] == nullptr)
+				continue; // a diagonal with no plaintext; the kernel skips it
+			if ((int)v[k]->limb.size() < limbsize)
+				throw std::runtime_error(std::string("FIDESlib: LTdotProductPtBatch would read ") + std::to_string(limbsize) +
+										 " limbs from " + what + "[" + std::to_string(k) + "], which holds " +
+										 std::to_string(v[k]->limb.size()) + ". The operands are at different levels.");
+		}
+	};
+	checkLimbs(out, "out");
+	checkLimbs(in, "in");
+	checkLimbs(pt, "pt");
 
 	assert(out.size() % (2 * gStep * stride) == 0);
 	assert(in.size() % (2 * bStep * stride) == 0);

--- a/src/CKKS/openfhe-interface/RawCiphertext.cu
+++ b/src/CKKS/openfhe-interface/RawCiphertext.cu
@@ -8,6 +8,10 @@
 #include "Math.cuh"
 #include <bit>
 #include <cassert>
+#include <iostream>
+#include <map>
+#include <set>
+#include <string>
 using namespace lbcrypto;
 
 /**
@@ -1193,6 +1197,18 @@ void FIDESlib::CKKS::AddBootstrapPlaintexts(lbcrypto::CryptoContext<lbcrypto::DC
 					if constexpr (remove_extension)
 						result.CtS.at(i).A.back().c0.freeSpecialLimbs();
 				}
+			}
+
+			// Which side of the seam a level mismatch is on is not otherwise visible: the tower count
+			// of these diagonals is decided entirely by OpenFHE's EvalBootstrapSetup (GetRawPlainText
+			// just reports GetAllElements().size()), while the ciphertext's post-ModRaise level is
+			// chosen here, by scaling technique. Print both once so the two are comparable in a log.
+			// A FIXEDMANUAL context grows the ciphertext to L, i.e. L + 1 limbs; anything less here is
+			// the gap that EvalCoeffsToSlots has to drop the ciphertext across.
+			if (!result.CtS.empty() && !result.CtS.front().A.empty()) {
+				std::cerr << "[FIDESlib] bootstrap diagonals: CtS layer 0 holds "
+						  << result.CtS.front().A.front().c0.getLevel() + 1 << " limbs; a ciphertext at L=" << GPUcc.L
+						  << " has " << GPUcc.L + 1 << " (scaling technique " << (int)GPUcc.rescaleTechnique << ")" << std::endl;
 			}
 
 			for (uint32_t i = 0; i < invA.size(); ++i) {

--- a/src/ConstantsGPU.cu
+++ b/src/ConstantsGPU.cu
@@ -7,6 +7,8 @@
 #include <algorithm>
 #include <bit>
 #include <cassert>
+#include <stdexcept>
+#include <string>
 
 #include "CKKS/Parameters.cuh"
 #include "parallel_for.hpp"
@@ -133,6 +135,24 @@ std::pair<std::vector<Constants>, std::unique_ptr<Global>> SetupConstants(const 
   const int N,
   const Scheme& parameters) {
 	CudaCheckErrorMod;
+
+	// Every constant table below is `[MAXP]`, and MAXP is also the *stride* the kernels index the
+	// flattened pointer tables with (`i * MAXP + primeid`). The special primes are written at
+	// `primes[L + i]`, so the whole scheme needs `L + K <= MAXP` - and nothing used to check it.
+	// Going over does not fail: it writes past `primes` into `prime_better_barret_mu` and onwards,
+	// so the symptom depends on how far the overflow reaches. Observed on a GV100 at N=2^16,
+	// dnum=3: silent NaN out of `EvalMultByI` first, then an illegal memory access, and finally
+	// `cudaMemcpy 'invalid argument'` here once the overrun reached the device-side copies. All
+	// three were reported as separate bugs. Fail with the numbers instead.
+	if (q.size() + p.size() > (size_t)MAXP) {
+		throw std::runtime_error(
+			"FIDESlib: this parameter set needs " + std::to_string(q.size()) + " ciphertext primes + " +
+			std::to_string(p.size()) + " special primes = " + std::to_string(q.size() + p.size()) +
+			", but the GPU constant tables hold MAXP = " + std::to_string(MAXP) +
+			". Lower `depth`, or raise `dnum` (which shrinks the special-prime count K), or raise MAXP "
+			"in src/ConstantsGPU.cuh and rebuild - note MAXP costs O(MAXP^3) constant memory through "
+			"DecompAndModUp_matrix, so raising it is not free.");
+	}
 
 	initGPUprop();
 


### PR DESCRIPTION
## What

Gets FIDESlib building and running on a V100 (sm_70) with CUDA 12.x. Two parts:

1. **CMake picks the CUDA archs for you.** If `FIDESLIB_ARCH` isn't set, it reads the GPUs from `nvidia-smi` and the toolkit version from `nvcc --version`, then builds for the GPUs that nvcc actually supports. With no GPU visible, you get the old fat list clipped to what nvcc accepts. `-DFIDESLIB_ARCH=70-real` (or any list) still overrides all of it.
2. **Fixes for the bugs that showed up once it ran on a GV100.** Mostly out-of-bounds reads that surfaced as illegal-address errors far from where they happened, plus a few API correctness fixes picked up along the way.

## Why

The default arch list starts at `80-real`, so a V100 got no kernel image at all. No single hardcoded list works everywhere: CUDA 13 dropped sm_70, and toolkits older than 12.8 don't know sm_100/sm_120.

Once it did run, these came up:

| Symptom on the GV100 | Root cause | Fix |
|---|---|---|
| NaN out of `EvalMultByI`, then an illegal memory access, then `cudaMemcpy 'invalid argument'` (N = 2^16, dnum = 3) | `L + K` > `MAXP`, so the special primes get written past the end of the `[MAXP]` constant tables. Nothing checked it. | `SetupConstants` now throws with the actual counts and what to change (`depth`, `dnum` or `MAXP`) |
| `LTdotProductPtBatch` reading 35 limbs from a plaintext that holds 34 (bootstrap, FIXEDMANUAL) | OpenFHE encodes the CtS/StC diagonals one level below where our ModRaise leaves the ciphertext | `EvalCoeffsToSlots` drops the ciphertext to each layer's diagonal level before the product, which is what OpenFHE's `AdjustLevelsAndDepth` does implicitly |
| Illegal access reported from a `GPUfree` several calls later | `multMonomial` can index past `limb` on a pooled polynomial that wasn't grown to its level | Explicit limb-count check that throws right there |

`LTdotProductPtBatch` also checks every operand's limb count against the launch size now, so a level mismatch fails with a readable message instead of a garbage device pointer.

API fixes in `api/CryptoContext.cpp`:

- **`EvalSub(scalar, ct)`:** on GPU this returned `ct - scalar`. Dropped the extra `multScalar(-1.0)`.
- **`EvalMult(ct, pt)` / `EvalMultInPlace(ct, pt)`, CPU fallback:** these `any_cast` to `ConstPlaintext`, but `pt->cpu` always holds a `Plaintext`, so they threw `bad_any_cast`.
- **`~CryptoContextImpl`:** it called the no-arg `ClearEvalMultKeys()` / `ClearEvalAutomorphismKeys()`, which wipe OpenFHE's *global* key maps, i.e. every other live context's keys too. Removed. OpenFHE's own `CryptoContextImpl` doesn't do this either.

Also, `KeySwitchingKey` held a `Context&` that dangled once `LoadContext` moved its local `Context` into `std::any`. It's now a `std::weak_ptr<ContextData>` behind a `context()` accessor. It's deliberately not a `shared_ptr`: keys live inside `ContextData`, so owning it would make a cycle and no context would ever be freed.

## Why it is safe

- All the new checks run on the host before a launch and cost O(number of operands). They only throw where the old code would have read out of bounds.
- The `LTdotProductPtBatch` check skips `nullptr` diagonals, which the kernel skips as well. An earlier version of the check didn't, and that broke a working bootstrap.
- The level alignment in `EvalCoeffsToSlots` only ever drops the ciphertext, and only when it sits above that layer's diagonals. When the levels already match, it's a no-op.
- Arch detection only kicks in when `FIDESLIB_ARCH` isn't set. Explicit values behave exactly as before.

## Testing

The bugs above were hit and fixed on a GV100 (CUDA 12.x, sm_70). A full `fideslib-test` run on the V100 is in progress; I'll post the results here.

## Notes

- **Configuring on a machine with a GPU now builds only that GPU's arch** (`-real`, no PTX). That's great locally, but not what you want for a package or CI build, so pass `FIDESLIB_ARCH` explicitly there. Happy to make auto-detection opt-in instead if you'd prefer that.
- **The level-budget-1 bootstrap path (`EvalLinearTransform`) doesn't get the alignment yet.** If the same one-limb gap exists there, it now fails with the limb-count error instead of reading out of bounds.
- **`AddBootstrapPlaintexts` prints one diagnostic line to stderr per bootstrap setup.** It was handy while chasing the level gap, and I can put it behind a flag.
- **`.gitignore`:** added `__pycache__/`, `*.pyc` and `build-*/`.